### PR TITLE
US-1678-1725 - Reformula Pipeline de Análise de Emendas

### DIFF
--- a/coherence/inter_emd_int/inter_emd_int.py
+++ b/coherence/inter_emd_int/inter_emd_int.py
@@ -73,7 +73,7 @@ for file in files:
         line = re.sub(r'[^\w\d\s]+', '', line)
         tokenized_sentences.append(line.lower().split())
         stop_words = set(stopwords.words('portuguese') + list(punctuation))
-        print("Adicionando tokens para análise")
+        #print("Adicionando tokens para análise")
         for t in tokenized_sentences:
             emdSentences.append([w for w in t if w not in stop_words])
 

--- a/coherence/inter_emd_int/inter_emd_int.py
+++ b/coherence/inter_emd_int/inter_emd_int.py
@@ -67,17 +67,22 @@ def is_avulso_inicial(filename):
 emdSentences = []
 finalTokenizedSentences = []
 intFile = ""
+
+emendas = []
+
 for file in files:
     filename = str(file)
     #print("Filename: " + filename)
     #Verifica se o texto é de uma emenda
     if "emenda" in filename:
+        emendas.append(file)
         file = open(emdPath + '/' + filename, 'r', encoding = 'UTF8')
         line = file.read()
         tokenized_sentences = []
         line = re.sub(r'[^\w\d\s]+', '', line)
         tokenized_sentences.append(line.lower().split())
         stop_words = set(stopwords.words('portuguese') + list(punctuation))
+        print("Adicionando tokens para análise")
         for t in tokenized_sentences:
             emdSentences.append([w for w in t if w not in stop_words])
 
@@ -86,9 +91,6 @@ for file in files:
         intFile = open(emdPath + '/' + filename, 'r', encoding = 'UTF8') 
         id_proposicao = filename.split('_')[1]
         #print("ID Proposição: " + id_proposicao)
-        files.remove(file)
-    else:
-        files.remove(file)
 
 if len(emdSentences) == 0:
     print("Não existe Emendas para esta proposição")
@@ -122,7 +124,7 @@ allDists = []
 indexes = []
 files_read = []
 
-for emd,i in zip(emdSentences,files):
+for emd,i in zip(emdSentences,emendas):
     prefixo_emenda = i.split('.txt')[0]
     files_read.append(prefixo_emenda)
 

--- a/coherence/inter_emd_int/inter_emd_int.py
+++ b/coherence/inter_emd_int/inter_emd_int.py
@@ -55,15 +55,6 @@ DOCS_AVULSO_INICIAL = ["avulso_inicial_da_materia","apresentacao_de_proposicao",
 
 # Lista de Sentenças de cada emenda
 
-def is_avulso_inicial(filename):
-    result = False
-    for doc_name in DOCS_AVULSO_INICIAL:
-        if doc_name in filename:
-            result = True
-            break
-    return result
-
-    
 emdSentences = []
 finalTokenizedSentences = []
 intFile = ""
@@ -74,7 +65,7 @@ for file in files:
     filename = str(file)
     #print("Filename: " + filename)
     #Verifica se o texto é de uma emenda
-    if "emenda" in filename:
+    if 'emenda' in filename:
         emendas.append(file)
         file = open(emdPath + '/' + filename, 'r', encoding = 'UTF8')
         line = file.read()
@@ -87,7 +78,7 @@ for file in files:
             emdSentences.append([w for w in t if w not in stop_words])
 
     #Verifica se existe o texto inicial da materia
-    elif is_avulso_inicial(filename):
+    elif 'avulso' in filename:
         intFile = open(emdPath + '/' + filename, 'r', encoding = 'UTF8') 
         id_proposicao = filename.split('_')[1]
         #print("ID Proposição: " + id_proposicao)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,8 @@ services:
      - leggo_content_data:/leggo-content/leggo_content_data
 
 volumes:
-  leggo_content_data:
-    external:
-      name: leggo_content_data
   leggo_data:
     external:
       name: leggo_data
+  leggo_content_data:
+    name: leggo_content_data

--- a/run_emendas_analysis.sh
+++ b/run_emendas_analysis.sh
@@ -25,7 +25,7 @@ date
 
 pretty_print "Copiando os arquivos de entrada para o volume do leggo-content"
     cp $LEGGO_DATA_MOUNT_PATH/novas_emendas.csv $VOLUME_MOUNT_PATH/novas_emendas.csv
-    cp $LEGGO_DATA_MOUNT_PATH/avulsos_iniciais.csv $VOLUME_MOUNT_PATH/avulsos_iniciais.csv
+    cp $LEGGO_DATA_MOUNT_PATH/avulsos_iniciais_novas_emendas.csv $VOLUME_MOUNT_PATH/avulsos_iniciais_novas_emendas.csv
 
 pretty_print "Verificando se há novas emendas"
 if [ $(cat $VOLUME_MOUNT_PATH/novas_emendas.csv | wc -l) -lt 2 ]
@@ -40,7 +40,7 @@ else
 
     pretty_print "Baixando os arquivos em pdf"
         python3 util/data/download_csv_prop.py $VOLUME_MOUNT_PATH/novas_emendas.csv id_ext codigo_emenda emenda $VOLUME_MOUNT_PATH/documentos/ 
-        python3 util/data/download_csv_prop.py $VOLUME_MOUNT_PATH/avulsos_iniciais.csv id_proposicao codigo_texto avulso $VOLUME_MOUNT_PATH/documentos/ 
+        python3 util/data/download_csv_prop.py $VOLUME_MOUNT_PATH/avulsos_iniciais_novas_emendas.csv id_proposicao codigo_texto avulso $VOLUME_MOUNT_PATH/documentos/ 
 
     pretty_print "Convertendo de pdf para txt"
         util/data/calibre_convert.sh $VOLUME_MOUNT_PATH/documentos $VOLUME_MOUNT_PATH/log-arquivos-sem-texto.txt

--- a/run_emendas_analysis.sh
+++ b/run_emendas_analysis.sh
@@ -23,8 +23,9 @@ pretty_print "Iniciando atualização"
 # Registra a data de início
 date
 
-pretty_print "Limpando as pastas antes de iniciar o pipeline"	
-rm -rf $VOLUME_MOUNT_PATH/documentos $VOLUME_MOUNT_PATH/documentos_sem_justificacoes/ 
+pretty_print "Copiando os arquivos de entrada para o volume do leggo-content"
+    cp $LEGGO_DATA_MOUNT_PATH/novas_emendas.csv $VOLUME_MOUNT_PATH/novas_emendas.csv
+    cp $LEGGO_DATA_MOUNT_PATH/avulsos_iniciais.csv $VOLUME_MOUNT_PATH/avulsos_iniciais.csv
 
 pretty_print "Verificando se há novas emendas"
 if [ $(cat $VOLUME_MOUNT_PATH/novas_emendas.csv | wc -l) -lt 2 ]
@@ -32,11 +33,14 @@ then
     echo "Não há novas emendas"
     exit 0
 else
+    pretty_print "Limpando as pastas antes de iniciar o pipeline"	
+    rm -rf $VOLUME_MOUNT_PATH/documentos $VOLUME_MOUNT_PATH/documentos_sem_justificacoes/ 
+
     mkdir -p $VOLUME_MOUNT_PATH/documentos
 
     pretty_print "Baixando os arquivos em pdf"
-        python3 util/data/download_csv_prop.py $VOLUME_MOUNT_PATH/novas_emendas.csv $VOLUME_MOUNT_PATH/documentos/ 
-        python3 util/data/download_csv_prop.py $VOLUME_MOUNT_PATH/avulsos_iniciais.csv $VOLUME_MOUNT_PATH/documentos/ 
+        python3 util/data/download_csv_prop.py $VOLUME_MOUNT_PATH/novas_emendas.csv id_ext codigo_emenda emenda $VOLUME_MOUNT_PATH/documentos/ 
+        python3 util/data/download_csv_prop.py $VOLUME_MOUNT_PATH/avulsos_iniciais.csv id_proposicao codigo_texto avulso $VOLUME_MOUNT_PATH/documentos/ 
 
     pretty_print "Convertendo de pdf para txt"
         util/data/calibre_convert.sh $VOLUME_MOUNT_PATH/documentos $VOLUME_MOUNT_PATH/log-arquivos-sem-texto.txt

--- a/util/data/download_csv_prop.py
+++ b/util/data/download_csv_prop.py
@@ -18,13 +18,14 @@ def download_pdfs_from_path(csv_path, campo_prop_id, campo_doc_id, tipo_texto, o
       try:
   
         link = row["inteiro_teor"]
+        casa = row["casa"]
         id_proposicao = str(row[campo_prop_id])
         cd_texto = str(row[campo_doc_id])
 
         full_outputpath = os.path.join(output_dir, id_proposicao, "pdf")
         os.makedirs(full_outputpath, exist_ok=True)
   
-        file_name_tipo = "%s_%s_%s.pdf" % (cd_texto, id_proposicao, tipo_texto)
+        file_name_tipo = "%s_%s_%s_%s.pdf" % (cd_texto, id_proposicao, casa, tipo_texto)
         file_name = os.path.join(full_outputpath, file_name_tipo)
         print(str(link),'->',file_name)
         urllib.request.urlretrieve(link, file_name)

--- a/util/data/download_csv_prop.py
+++ b/util/data/download_csv_prop.py
@@ -6,9 +6,9 @@ import unidecode
 import traceback
 
 def print_usage():
-  print("Número errado de parâmetros,o certo é: donwload_csv_props.py <caminho_csv_links_arquivos> <output_dir>")
+  print("Número errado de parâmetros,o certo é: donwload_csv_props.py <caminho_csv_links_arquivos> <campo_prop_id> <campo_doc_id> <tipo_texto> <output_dir>")
 
-def download_pdfs_from_path(csv_path):
+def download_pdfs_from_path(csv_path, campo_prop_id, campo_doc_id, tipo_texto, output_dir):
   df = pd.read_csv(csv_path)
   
   count_tipo = {}
@@ -17,32 +17,27 @@ def download_pdfs_from_path(csv_path):
 
       try:
   
-        link = row["link_inteiro_teor"]
-        id_proposicao = str(row["id_proposicao"])
-        cd_texto = str(row["codigo_texto"])
+        link = row["inteiro_teor"]
+        id_proposicao = str(row[campo_prop_id])
+        cd_texto = str(row[campo_doc_id])
+
+        full_outputpath = os.path.join(output_dir, id_proposicao, "pdf")
+        os.makedirs(full_outputpath, exist_ok=True)
   
-        full_outputpath = os.path.join(output_dir, id_proposicao)
-  
-        if not(os.path.exists(full_outputpath)):
-          os.mkdir(full_outputpath)
-  
-        full_outputpath = os.path.join(full_outputpath, "pdf")
-        if not(os.path.exists(full_outputpath)):
-          os.mkdir(full_outputpath)
-  
-        tipo = unidecode.unidecode(row["tipo_texto"].lower())
-  
-        file_name_tipo = "%s_%s_%s.pdf" % (cd_texto, id_proposicao, tipo.replace(" ","_"))
+        file_name_tipo = "%s_%s_%s.pdf" % (cd_texto, id_proposicao, tipo_texto)
         file_name = os.path.join(full_outputpath, file_name_tipo)
-        print(file_name)
+        print(str(link),'->',file_name)
         urllib.request.urlretrieve(link, file_name)
       except:
           print(traceback.format_exc())
 
-if (len(sys.argv) != 3):
+if (len(sys.argv) != 6):
   print_usage()
 else:
   links_arquivos = sys.argv[1]
-  output_dir = sys.argv[2]
+  campo_prop_id = sys.argv[2]
+  campo_doc_id = sys.argv[3]
+  tipo_texto = sys.argv[4]
+  output_dir = sys.argv[5]
 
-  download_pdfs_from_path(links_arquivos)
+  download_pdfs_from_path(links_arquivos, campo_prop_id, campo_doc_id, tipo_texto, output_dir)

--- a/util/tools/SepararJustificacoes.py
+++ b/util/tools/SepararJustificacoes.py
@@ -40,14 +40,7 @@ else:
     patterns = [pat, pat2, pat3]
     textosPat = [r"\njustificação\n", r"\njustificativa\n", ""]
 
-    # # Cria diretrio se não existe
-    def createDirsIfNotExists(path):
-        if not os.path.exists(path):
-            os.makedirs(path)
-
-    #dirPath = "./pls_leis_tramitacoes/textos_iniciais_txt"
-    #justificacoesPath = "./justificacoes/"
-    createDirsIfNotExists(justificacoesPath)
+    os.makedirs(justificacoesPath, exist_ok=True)
 
     fps = []
 
@@ -55,7 +48,7 @@ else:
         for filename in filenames:
                 # Cria diretórios no formato /justificacoes/numProposicao/arquivos.txt
                 newPath = justificacoesPath + "/" + filename.split("_")[1] + "/"
-                createDirsIfNotExists(newPath)
+                os.makedirs(newPath, exist_ok=True)
                 docPath = os.path.join(dirpath,filename)
                 with open(os.path.normpath(docPath), "r", encoding = "utf-8") as pl:
                     ProjetoDeLei = pl.read()


### PR DESCRIPTION
## Mudanças
- Modifica docker-compose, dando acesso aos dados do leggoR para que os arquivos de entrada da análise de emendas possam ser copiados diretamente pelo container do leggo-content para o seu volume.
- Refatoramentos diversos nos scripts usados na análise, removendo funções e código desnecessário/ineficiente.
- Adiciona parâmetros ao script que baixa os pdfs dos textos, tornando-o mais reutilizável/genérico.
- Simplifica verificação de texto inicial da matéria.
- Adiciona nome da casa ao nome do arquivo para facilitar indexação ao final do processamento.

## Como Testar
- Deve ser avaliado (especialmente merjado) em conjunto com os PRs correspondentes nos outros repositórios: [leggo-geral](https://github.com/parlametria/leggo-geral/pull/14), [leggoR](https://github.com/parlametria/leggoR/pull/535) e [rcongresso](https://github.com/analytics-ufcg/rcongresso/pull/179)
- Instruções de teste para o pipeline inteiro no PR do [leggo-geral](https://github.com/parlametria/leggo-geral/pull/14)